### PR TITLE
Add switchable pipeline views

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ import { Header } from './components/layout/Header';
 import { Sidebar } from './components/layout/Sidebar';
 import { CommandPalette } from './components/ui/CommandPalette';
 import { MetricsGrid } from './components/dashboard/MetricsGrid';
-import { DualPipelineView } from './components/pipeline/DualPipelineView';
+import { PipelineView } from './components/pipeline/PipelineView';
 import { LoadingSpinner } from './components/ui/LoadingSpinner';
 import { OpportunityModal } from './components/modals/OpportunityModal';
 import { JobModal } from './components/modals/JobModal';
@@ -41,7 +41,9 @@ const AppContent: React.FC = () => {
     setOpportunityModalOpen,
     setEditingOpportunity,
     setJobModalOpen,
-    setEditingJob
+    setEditingJob,
+    metrics,
+    setMetrics
   } = useStore();
   
   useKeyboardShortcuts();
@@ -87,6 +89,18 @@ const AppContent: React.FC = () => {
     conversion_rate: 75.0, // Calculate this based on opportunities -> jobs conversion
     pipeline_velocity: 45 // Calculate this based on average time to close
   };
+
+  useEffect(() => {
+    setMetrics(combinedMetrics);
+  }, [
+    opportunityMetrics?.data?.total_pipeline_value,
+    jobMetrics?.data?.total_job_value,
+    opportunityMetrics?.data?.weighted_pipeline_value,
+    opportunityMetrics?.data?.total_opportunities,
+    jobMetrics?.data?.active_jobs,
+    opportunityMetrics?.data?.win_rate,
+    opportunityMetrics?.data?.avg_deal_size
+  ]);
 
   const isLoading = opportunitiesLoading || jobsLoading;
   const hasError = opportunitiesError || jobsError;
@@ -134,14 +148,14 @@ const AppContent: React.FC = () => {
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5 }}
           >
-            <MetricsGrid metrics={combinedMetrics} />
+            <MetricsGrid metrics={metrics || combinedMetrics} />
             
             {isLoading ? (
               <div className="flex items-center justify-center py-12">
                 <LoadingSpinner size="lg" />
               </div>
             ) : (
-              <DualPipelineView
+              <PipelineView
                 opportunities={opportunitiesData?.data || []}
                 jobs={jobsData?.data || []}
                 onCreateOpportunity={handleCreateOpportunity}

--- a/src/components/pipeline/CalendarView.tsx
+++ b/src/components/pipeline/CalendarView.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import type { Opportunity, Job } from '../../types';
+
+interface CalendarViewProps {
+  opportunities: Opportunity[];
+  jobs: Job[];
+  onEditOpportunity: (op: Opportunity) => void;
+  onEditJob: (job: Job) => void;
+}
+
+export const CalendarView: React.FC<CalendarViewProps> = ({
+  opportunities,
+  jobs,
+  onEditOpportunity,
+  onEditJob
+}) => {
+  const events = [
+    ...opportunities.map(op => ({
+      id: op.id,
+      date: op.expected_confirmation_date,
+      type: 'opportunity' as const,
+      name: op.name
+    })),
+    ...jobs.map(job => ({
+      id: job.id,
+      date: job.expected_confirmation_date,
+      type: 'job' as const,
+      name: job.name
+    }))
+  ];
+
+  const grouped = events.reduce<Record<string, typeof events>>( (acc, evt) => {
+    const day = new Date(evt.date).toDateString();
+    acc[day] = acc[day] || [];
+    acc[day].push(evt);
+    return acc;
+  }, {});
+
+  return (
+    <div className="space-y-6">
+      {Object.entries(grouped).map(([day, dayEvents]) => (
+        <div key={day}>
+          <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
+            {day}
+          </h3>
+          <div className="space-y-2">
+            {dayEvents.map(ev => (
+              <div
+                key={ev.type + ev.id}
+                className="p-3 bg-white/70 dark:bg-gray-800/70 rounded-lg border border-gray-200/50 dark:border-gray-700/50 cursor-pointer"
+                onClick={() => ev.type === 'opportunity' ? onEditOpportunity(opportunities.find(o => o.id === ev.id)! ) : onEditJob(jobs.find(j => j.id === ev.id)!)}
+              >
+                {ev.name}
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/components/pipeline/KanbanView.tsx
+++ b/src/components/pipeline/KanbanView.tsx
@@ -4,7 +4,7 @@ import { ArrowRight, Plus, MoreHorizontal } from 'lucide-react';
 import { OPPORTUNITY_STAGES, JOB_STAGES, INDUSTRY_GROUPS } from '../../constants';
 import type { Opportunity, Job } from '../../types';
 
-interface DualPipelineViewProps {
+interface KanbanViewProps {
   opportunities: Opportunity[];
   jobs: Job[];
   onCreateOpportunity: () => void;
@@ -13,7 +13,7 @@ interface DualPipelineViewProps {
   onEditJob: (job: Job) => void;
 }
 
-export const DualPipelineView: React.FC<DualPipelineViewProps> = ({
+export const KanbanView: React.FC<KanbanViewProps> = ({
   opportunities,
   jobs,
   onCreateOpportunity,

--- a/src/components/pipeline/ListView.tsx
+++ b/src/components/pipeline/ListView.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import type { Opportunity, Job } from '../../types';
+
+interface ListViewProps {
+  opportunities: Opportunity[];
+  jobs: Job[];
+  onEditOpportunity: (op: Opportunity) => void;
+  onEditJob: (job: Job) => void;
+}
+
+export const ListView: React.FC<ListViewProps> = ({
+  opportunities,
+  jobs,
+  onEditOpportunity,
+  onEditJob
+}) => {
+  return (
+    <div className="space-y-8">
+      <div>
+        <h3 className="text-lg font-semibold mb-2 text-gray-900 dark:text-white">Opportunities</h3>
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm">
+          <thead>
+            <tr>
+              <th className="px-2 py-1 text-left">Name</th>
+              <th className="px-2 py-1 text-left">Value</th>
+              <th className="px-2 py-1 text-left">Stage</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+            {opportunities.map(op => (
+              <tr key={op.id} className="hover:bg-gray-50 dark:hover:bg-gray-800 cursor-pointer" onClick={() => onEditOpportunity(op)}>
+                <td className="px-2 py-1">{op.name}</td>
+                <td className="px-2 py-1">${'{'}op.value.toLocaleString(){'}'}</td>
+                <td className="px-2 py-1">{op.stage}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div>
+        <h3 className="text-lg font-semibold mb-2 text-gray-900 dark:text-white">Jobs</h3>
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm">
+          <thead>
+            <tr>
+              <th className="px-2 py-1 text-left">Name</th>
+              <th className="px-2 py-1 text-left">Value</th>
+              <th className="px-2 py-1 text-left">Stage</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+            {jobs.map(job => (
+              <tr key={job.id} className="hover:bg-gray-50 dark:hover:bg-gray-800 cursor-pointer" onClick={() => onEditJob(job)}>
+                <td className="px-2 py-1">{job.name}</td>
+                <td className="px-2 py-1">${'{'}job.value.toLocaleString(){'}'}</td>
+                <td className="px-2 py-1">{job.stage}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};

--- a/src/components/pipeline/PipelineView.tsx
+++ b/src/components/pipeline/PipelineView.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { useStore } from '../../store/useStore';
+import type { Opportunity, Job } from '../../types';
+import { KanbanView } from './KanbanView';
+import { TimelineView } from './TimelineView';
+import { CalendarView } from './CalendarView';
+import { ListView } from './ListView';
+
+export interface PipelineViewProps {
+  opportunities: Opportunity[];
+  jobs: Job[];
+  onCreateOpportunity: () => void;
+  onCreateJob: () => void;
+  onEditOpportunity: (op: Opportunity) => void;
+  onEditJob: (job: Job) => void;
+}
+
+export const PipelineView: React.FC<PipelineViewProps> = (props) => {
+  const { viewMode } = useStore();
+
+  switch (viewMode.type) {
+    case 'timeline':
+      return <TimelineView {...props} />;
+    case 'calendar':
+      return <CalendarView {...props} />;
+    case 'list':
+      return <ListView {...props} />;
+    case 'kanban':
+    default:
+      return <KanbanView {...props} />;
+  }
+};

--- a/src/components/pipeline/TimelineView.tsx
+++ b/src/components/pipeline/TimelineView.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import type { Opportunity, Job } from '../../types';
+
+interface TimelineViewProps {
+  opportunities: Opportunity[];
+  jobs: Job[];
+  onEditOpportunity: (op: Opportunity) => void;
+  onEditJob: (job: Job) => void;
+}
+
+export const TimelineView: React.FC<TimelineViewProps> = ({
+  opportunities,
+  jobs,
+  onEditOpportunity,
+  onEditJob
+}) => {
+  const events = [
+    ...opportunities.map(op => ({
+      id: op.id,
+      date: op.expected_confirmation_date,
+      type: 'opportunity' as const,
+      data: op
+    })),
+    ...jobs.map(job => ({
+      id: job.id,
+      date: job.expected_confirmation_date,
+      type: 'job' as const,
+      data: job
+    }))
+  ].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+
+  return (
+    <div className="space-y-4">
+      {events.map(evt => (
+        <div
+          key={evt.type + evt.id}
+          className="p-4 bg-white/70 dark:bg-gray-800/70 rounded-lg border border-gray-200/50 dark:border-gray-700/50 cursor-pointer"
+          onClick={() => evt.type === 'opportunity' ? onEditOpportunity(evt.data as Opportunity) : onEditJob(evt.data as Job)}
+        >
+          <div className="text-sm text-gray-500 mb-1">
+            {new Date(evt.date).toLocaleDateString()}
+          </div>
+          <div className="font-medium text-gray-900 dark:text-white">
+            {evt.type === 'opportunity' ? (evt.data as Opportunity).name : (evt.data as Job).name}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- support multiple pipeline views
- default to Kanban view but provide Timeline, Calendar, and List
- update App to store metrics in the global store

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_684410604ed4832aa676515488a46cda