### PR TITLE
Implement command palette routing and export service

### DIFF
--- a/src/components/ui/CommandPalette.tsx
+++ b/src/components/ui/CommandPalette.tsx
@@ -1,11 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import { Command } from 'cmdk';
 import { motion, AnimatePresence } from 'framer-motion';
-import { 
-  Search, Plus, BarChart3, Users, Settings, 
-  FileText, Calendar, Filter, Download 
+import {
+  Search, Plus, BarChart3, Users, Settings,
+  FileText, Calendar, Filter, Download
 } from 'lucide-react';
 import { useStore } from '../../store/useStore';
+import { useNavigate } from 'react-router-dom';
+import { exportService } from '../../services/exportService';
 
 interface CommandItem {
   id: string;
@@ -17,8 +19,8 @@ interface CommandItem {
 }
 
 export const CommandPalette: React.FC = () => {
-  const { 
-    commandPaletteOpen, 
+  const {
+    commandPaletteOpen,
     setCommandPaletteOpen,
     setOpportunityModalOpen,
     setJobModalOpen,
@@ -26,6 +28,7 @@ export const CommandPalette: React.FC = () => {
     setEditingJob
   } = useStore();
   const [search, setSearch] = useState('');
+  const navigate = useNavigate();
 
   const commands: CommandItem[] = [
     {
@@ -58,7 +61,7 @@ export const CommandPalette: React.FC = () => {
       subtitle: 'Open analytics dashboard',
       icon: <BarChart3 className="h-4 w-4" />,
       action: () => {
-        // TODO: Navigate to analytics
+        navigate('/analytics');
         setCommandPaletteOpen(false);
       },
       keywords: ['analytics', 'dashboard', 'metrics', 'reports']
@@ -69,7 +72,7 @@ export const CommandPalette: React.FC = () => {
       subtitle: 'Manage team members and roles',
       icon: <Users className="h-4 w-4" />,
       action: () => {
-        // TODO: Navigate to team
+        navigate('/team');
         setCommandPaletteOpen(false);
       },
       keywords: ['team', 'users', 'members', 'roles']
@@ -80,7 +83,7 @@ export const CommandPalette: React.FC = () => {
       subtitle: 'Switch to calendar view',
       icon: <Calendar className="h-4 w-4" />,
       action: () => {
-        // TODO: Switch to calendar view
+        navigate('/calendar');
         setCommandPaletteOpen(false);
       },
       keywords: ['calendar', 'schedule', 'dates', 'timeline']
@@ -91,7 +94,7 @@ export const CommandPalette: React.FC = () => {
       subtitle: 'Export pipeline data to CSV',
       icon: <Download className="h-4 w-4" />,
       action: () => {
-        // TODO: Export data
+        exportService.exportPipelineCSV();
         setCommandPaletteOpen(false);
       },
       keywords: ['export', 'download', 'csv', 'data']

--- a/src/services/exportService.ts
+++ b/src/services/exportService.ts
@@ -1,0 +1,58 @@
+import { opportunityService } from './opportunityService';
+import { jobService } from './jobService';
+
+export const exportService = {
+  async exportPipelineCSV() {
+    try {
+      const { data: opportunities } = await opportunityService.getAll();
+      const { data: jobs } = await jobService.getAll();
+      const rows: Record<string, any>[] = [];
+
+      opportunities?.forEach(o => {
+        rows.push({
+          type: 'Opportunity',
+          id: o.id,
+          name: o.name,
+          value: o.value,
+          stage: o.stage,
+          probability: o.probability,
+          created_at: o.created_at
+        });
+      });
+
+      jobs?.forEach(j => {
+        rows.push({
+          type: 'Job',
+          id: j.id,
+          name: j.name,
+          value: j.value,
+          stage: j.stage,
+          project_status: j.project_status,
+          created_at: j.created_at
+        });
+      });
+
+      if (rows.length === 0) return;
+
+      const headers = Object.keys(rows[0]);
+      const csv = [
+        headers.join(','),
+        ...rows.map(row =>
+          headers
+            .map(h => `"${String(row[h] ?? '').replace(/"/g, '""')}"`)
+            .join(',')
+        )
+      ].join('\n');
+
+      const blob = new Blob([csv], { type: 'text/csv' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `pipeline_export_${new Date().toISOString().split('T')[0]}.csv`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (error) {
+      console.error('Error exporting pipeline data:', error);
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- add `exportService` for CSV export
- wire command palette items to routes and export service

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: 47 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684413d05f04832aa531d338bcbf14ca