### PR TITLE
Add filter drawer with refetch

### DIFF
--- a/src/components/FilterDrawer.tsx
+++ b/src/components/FilterDrawer.tsx
@@ -1,0 +1,168 @@
+import React from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { X } from 'lucide-react';
+import { useStore } from '../store/useStore';
+import { useUsers } from '../hooks/useSupabaseQuery';
+import { OPPORTUNITY_STAGES, JOB_STAGES, INDUSTRY_GROUPS } from '../constants';
+import type { FilterState } from '../types';
+
+export const FilterDrawer: React.FC = () => {
+  const {
+    isFilterDrawerOpen,
+    setFilterDrawerOpen,
+    filters,
+    setFilters,
+    clearFilters,
+  } = useStore();
+
+  const { data: clientLeadersData } = useUsers({ role: 'client_leader' });
+  const clientLeaders = clientLeadersData?.data || [];
+
+  const allStages = [...OPPORTUNITY_STAGES, ...JOB_STAGES];
+
+  const toggleArrayValue = (
+    key: keyof Pick<FilterState, 'client_leaders' | 'industry_groups' | 'stages'>,
+    value: string
+  ) => {
+    const current = (filters as any)[key] as string[];
+    const updated = current.includes(value)
+      ? current.filter((v) => v !== value)
+      : [...current, value];
+    setFilters({ [key]: updated } as Partial<FilterState>);
+  };
+
+  const handleDateChange = (field: 'start' | 'end', value: string) => {
+    setFilters({ date_range: { ...filters.date_range, [field]: value } });
+  };
+
+  return (
+    <AnimatePresence>
+      {isFilterDrawerOpen && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          className="fixed inset-0 z-40 bg-black/50 backdrop-blur-sm flex justify-end"
+          onClick={() => setFilterDrawerOpen(false)}
+        >
+          <motion.div
+            initial={{ x: 300 }}
+            animate={{ x: 0 }}
+            exit={{ x: 300 }}
+            transition={{ type: 'spring', damping: 25, stiffness: 200 }}
+            className="bg-white dark:bg-gray-900 w-80 max-w-full h-full p-6 overflow-y-auto border-l border-gray-200 dark:border-gray-700"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between mb-6">
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Filters</h2>
+              <button
+                onClick={() => setFilterDrawerOpen(false)}
+                className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+              >
+                <X className="h-5 w-5 text-gray-600 dark:text-gray-400" />
+              </button>
+            </div>
+
+            <div className="space-y-6">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  Search
+                </label>
+                <input
+                  type="text"
+                  value={filters.search_query}
+                  onChange={(e) => setFilters({ search_query: e.target.value })}
+                  className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:border-gray-600 dark:text-white"
+                />
+              </div>
+
+              <div>
+                <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Client Leaders</h3>
+                <div className="space-y-1 max-h-40 overflow-y-auto pr-1">
+                  {clientLeaders.map((user: any) => (
+                    <label key={user.id} className="flex items-center space-x-2">
+                      <input
+                        type="checkbox"
+                        className="form-checkbox rounded text-blue-600"
+                        checked={filters.client_leaders.includes(user.id)}
+                        onChange={() => toggleArrayValue('client_leaders', user.id)}
+                      />
+                      <span className="text-sm text-gray-700 dark:text-gray-300 truncate">
+                        {user.name}
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+
+              <div>
+                <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Industry Groups</h3>
+                <div className="space-y-1">
+                  {Object.entries(INDUSTRY_GROUPS).map(([key, group]) => (
+                    <label key={key} className="flex items-center space-x-2">
+                      <input
+                        type="checkbox"
+                        className="form-checkbox rounded text-blue-600"
+                        checked={filters.industry_groups.includes(key)}
+                        onChange={() => toggleArrayValue('industry_groups', key)}
+                      />
+                      <span className="text-sm text-gray-700 dark:text-gray-300 truncate">
+                        {group.name}
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+
+              <div>
+                <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Stages</h3>
+                <div className="space-y-1 max-h-40 overflow-y-auto pr-1">
+                  {allStages.map((stage) => (
+                    <label key={stage.id} className="flex items-center space-x-2">
+                      <input
+                        type="checkbox"
+                        className="form-checkbox rounded text-blue-600"
+                        checked={filters.stages.includes(stage.id)}
+                        onChange={() => toggleArrayValue('stages', stage.id)}
+                      />
+                      <span className="text-sm text-gray-700 dark:text-gray-300 truncate">
+                        {stage.name}
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+
+              <div>
+                <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Date Range</h3>
+                <div className="grid grid-cols-2 gap-2">
+                  <input
+                    type="date"
+                    value={filters.date_range.start}
+                    onChange={(e) => handleDateChange('start', e.target.value)}
+                    className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:border-gray-600 dark:text-white"
+                  />
+                  <input
+                    type="date"
+                    value={filters.date_range.end}
+                    onChange={(e) => handleDateChange('end', e.target.value)}
+                    className="w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:border-gray-600 dark:text-white"
+                  />
+                </div>
+              </div>
+
+              <div className="pt-4 border-t border-gray-200 dark:border-gray-700 flex justify-end">
+                <button
+                  onClick={clearFilters}
+                  className="px-4 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+                >
+                  Clear Filters
+                </button>
+              </div>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+};

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -7,12 +7,14 @@ import {
 import { useStore } from '../../store/useStore';
 
 export const Header: React.FC = () => {
-  const { 
-    sidebarOpen, 
-    setSidebarOpen, 
-    theme, 
-    setTheme, 
+  const {
+    sidebarOpen,
+    setSidebarOpen,
+    theme,
+    setTheme,
     setCommandPaletteOpen,
+    isFilterDrawerOpen,
+    setFilterDrawerOpen,
     filters,
     setFilters
   } = useStore();
@@ -69,10 +71,10 @@ export const Header: React.FC = () => {
         {/* Right Section */}
         <div className="flex items-center space-x-2">
           <button
-            onClick={() => {/* TODO: Toggle filters */}}
+            onClick={() => setFilterDrawerOpen(!isFilterDrawerOpen)}
             className={`p-2 rounded-lg transition-colors ${
-              hasActiveFilters 
-                ? 'bg-blue-100 dark:bg-blue-900 text-blue-600 dark:text-blue-400' 
+              hasActiveFilters
+                ? 'bg-blue-100 dark:bg-blue-900 text-blue-600 dark:text-blue-400'
                 : 'hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-600 dark:text-gray-400'
             }`}
           >

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -17,6 +17,7 @@ import { PipelineView } from '../components/pipeline/PipelineView';
 import { LoadingSpinner } from '../components/ui/LoadingSpinner';
 import { OpportunityModal } from '../components/modals/OpportunityModal';
 import { JobModal } from '../components/modals/JobModal';
+import { FilterDrawer } from '../components/FilterDrawer';
 
 const Dashboard: React.FC = () => {
   const {
@@ -33,14 +34,29 @@ const Dashboard: React.FC = () => {
 
   useKeyboardShortcuts();
 
-  const { data: opportunitiesData, isLoading: opportunitiesLoading, error: opportunitiesError } = useOpportunities(filters);
-  const { data: jobsData, isLoading: jobsLoading, error: jobsError } = useJobs(filters);
+  const {
+    data: opportunitiesData,
+    isLoading: opportunitiesLoading,
+    error: opportunitiesError,
+    refetch: refetchOpportunities
+  } = useOpportunities(filters);
+  const {
+    data: jobsData,
+    isLoading: jobsLoading,
+    error: jobsError,
+    refetch: refetchJobs
+  } = useJobs(filters);
   const { data: opportunityMetrics } = useOpportunityMetrics();
   const { data: jobMetrics } = useJobMetrics();
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
   }, [theme]);
+
+  useEffect(() => {
+    refetchOpportunities();
+    refetchJobs();
+  }, [filters, refetchOpportunities, refetchJobs]);
 
   const handleCreateOpportunity = () => {
     setEditingOpportunity(null);
@@ -121,6 +137,7 @@ const Dashboard: React.FC = () => {
       <CommandPalette />
       <OpportunityModal />
       <JobModal />
+      <FilterDrawer />
 
       <main className={`transition-all duration-300 ${sidebarOpen ? 'ml-64' : 'ml-0'} pt-6`}>
         <div className="px-4 sm:px-6 lg:px-8 pb-8">

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -16,6 +16,10 @@ interface AppState {
   
   commandPaletteOpen: boolean;
   setCommandPaletteOpen: (open: boolean) => void;
+
+  // Filters Drawer
+  isFilterDrawerOpen: boolean;
+  setFilterDrawerOpen: (open: boolean) => void;
   
   // Modal State
   isOpportunityModalOpen: boolean;
@@ -79,6 +83,9 @@ export const useStore = create<AppState>()(
       
       commandPaletteOpen: false,
       setCommandPaletteOpen: (commandPaletteOpen) => set({ commandPaletteOpen }),
+
+      isFilterDrawerOpen: false,
+      setFilterDrawerOpen: (isFilterDrawerOpen) => set({ isFilterDrawerOpen }),
       
       // Modal State
       isOpportunityModalOpen: false,


### PR DESCRIPTION
## Summary
- add filter drawer state to useStore
- implement FilterDrawer component
- enable Header button to toggle the drawer
- trigger opportunities and jobs refetch on filter changes

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_684414da9d4c832aada9eb25c0e6f83f