### PR TITLE
Add job cache invalidation on opportunity update

### DIFF
--- a/src/hooks/useSupabaseQuery.ts
+++ b/src/hooks/useSupabaseQuery.ts
@@ -43,6 +43,8 @@ export const useUpdateOpportunity = () => {
       queryClient.invalidateQueries({ queryKey: ['opportunities'] });
       queryClient.invalidateQueries({ queryKey: ['opportunity', variables.id] });
       queryClient.invalidateQueries({ queryKey: ['opportunity-metrics'] });
+      queryClient.invalidateQueries({ queryKey: ['jobs'] });
+      queryClient.invalidateQueries({ queryKey: ['job-metrics'] });
     },
   });
 };


### PR DESCRIPTION
## Summary
- invalidate `jobs` cache when an opportunity updates
- invalidate job metrics for completeness

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68441785c668832ab901058b9e8677eb