### PR TITLE
Add settings route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import Analytics from './pages/Analytics';
 import Team from './pages/Team';
 import Accounts from './pages/Accounts';
 import Documents from './pages/Documents';
+import SettingsPage from './pages/Settings';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -37,6 +38,7 @@ const App: React.FC = () => (
           <Route path="/team" element={<Team />} />
           <Route path="/accounts" element={<Accounts />} />
           <Route path="/documents" element={<Documents />} />
+          <Route path="/settings" element={<SettingsPage />} />
         </Routes>
       </AuthProvider>
     </QueryClientProvider>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { motion } from 'framer-motion';
-import { 
-  Search, Menu, Bell, Settings, User, 
+import {
+  Search, Menu, Bell, Settings, User,
   Command, Sun, Moon, Plus, Filter
 } from 'lucide-react';
 import { useStore } from '../../store/useStore';
+import { useNavigate } from 'react-router-dom';
 
 export const Header: React.FC = () => {
   const {
@@ -18,6 +19,7 @@ export const Header: React.FC = () => {
     filters,
     setFilters
   } = useStore();
+  const navigate = useNavigate();
 
   const hasActiveFilters = Object.values(filters).some(value => 
     Array.isArray(value) ? value.length > 0 : value !== ''
@@ -100,7 +102,10 @@ export const Header: React.FC = () => {
             {theme === 'light' ? <Moon className="h-5 w-5" /> : <Sun className="h-5 w-5" />}
           </button>
 
-          <button className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-600 dark:text-gray-400 transition-colors">
+          <button
+            onClick={() => navigate('/settings')}
+            className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-600 dark:text-gray-400 transition-colors"
+          >
             <Settings className="h-5 w-5" />
           </button>
 

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+const SettingsPage: React.FC = () => (
+  <div className="p-6">
+    <h1 className="text-2xl font-semibold mb-4">Settings</h1>
+
+    <section className="mb-8">
+      <h2 className="text-xl font-semibold mb-2">User Profile</h2>
+      <p>Coming soon...</p>
+    </section>
+
+    <section>
+      <h2 className="text-xl font-semibold mb-2">Application Preferences</h2>
+      <p>Coming soon...</p>
+    </section>
+  </div>
+);
+
+export default SettingsPage;


### PR DESCRIPTION
## Summary
- add `SettingsPage` component
- register `/settings` route
- navigate to `/settings` from header settings icon

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844178481a8832aaa95e17823b0d290