### PR TITLE
Add test for opportunityService update

### DIFF
--- a/src/services/__tests__/opportunityService.test.ts
+++ b/src/services/__tests__/opportunityService.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { opportunityService } from '../opportunityService';
+
+// Mocks for Supabase operations
+const updatedOpportunity = {
+  id: '1',
+  name: 'Test Opp',
+  account_id: 'acc1',
+  value: 100,
+  stage: 'ready_for_proposal',
+  probability: 50,
+  client_leader_id: 'leader1',
+  expected_confirmation_date: null,
+  created_at: '',
+  updated_at: '',
+  notes: '',
+  source: '',
+  competitor: null,
+  lost_reason: null,
+};
+
+const updateSingleMock = vi.fn().mockResolvedValue({ data: updatedOpportunity, error: null });
+const updateSelectMock = vi.fn(() => ({ single: updateSingleMock }));
+const eqMock = vi.fn(() => ({ select: updateSelectMock }));
+const updateMock = vi.fn(() => ({ eq: eqMock }));
+
+const insertSingleMock = vi.fn().mockResolvedValue({ data: { id: 'job1' }, error: null });
+const insertSelectMock = vi.fn(() => ({ single: insertSingleMock }));
+const insertMock = vi.fn(() => ({ select: insertSelectMock }));
+
+vi.mock('../../lib/supabase', () => ({
+  supabase: {
+    from: (table: string) => {
+      if (table === 'opportunities') {
+        return { update: updateMock };
+      }
+      if (table === 'jobs') {
+        return { insert: insertMock };
+      }
+      throw new Error(`Unexpected table ${table}`);
+    },
+  },
+  logActivity: vi.fn(),
+  handleSupabaseError: vi.fn((e) => e),
+}));
+
+describe('opportunityService.update', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates a job when stage is ready_for_proposal', async () => {
+    await opportunityService.update('1', { stage: 'ready_for_proposal' } as any);
+    expect(insertMock).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add Vitest test for `opportunityService.update`
- mock Supabase client to validate job creation when an opportunity stage changes to `ready_for_proposal`

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684417888d08832aaef711e9a46b41c5